### PR TITLE
Dev fix timestamp issues causing parse failures; fix failed template import

### DIFF
--- a/automatic_install/non-xpack-corelight_main_pipeline
+++ b/automatic_install/non-xpack-corelight_main_pipeline
@@ -417,7 +417,7 @@
       "date_index_name" : {
         "field" : "event.ingested",
         "index_name_prefix" : "parse-failures-",
-        "date_formats": [ "yyyy-MM-dd'T'HH:mm:ss.SSSSSSXX", "yyyy-MM-dd'T'HH:mm:ss.SSSXX" ],
+        "date_formats": [ "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSXX", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSXX", "yyyy-MM-dd'T'HH:mm:ss.SSSXX" ],
         "date_rounding": "d",
         "ignore_failure": true,
         "index_name_format": "yyyy.MM.dd"

--- a/automatic_install/xpack-corelight_main_pipeline
+++ b/automatic_install/xpack-corelight_main_pipeline
@@ -417,7 +417,7 @@
       "date_index_name" : {
         "field" : "event.ingested",
         "index_name_prefix" : "parse-failures-",
-        "date_formats": [ "yyyy-MM-dd'T'HH:mm:ss.SSSSSSXX", "yyyy-MM-dd'T'HH:mm:ss.SSSXX" ],
+        "date_formats": [ "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSXX", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSXX", "yyyy-MM-dd'T'HH:mm:ss.SSSXX" ],
         "date_rounding": "d",
         "ignore_failure": true,
         "index_name_format": "yyyy.MM.dd"

--- a/manual_install/corelight_audit_log_pipeline
+++ b/manual_install/corelight_audit_log_pipeline
@@ -20,7 +20,7 @@ PUT _ingest/pipeline/corelight_audit_log_pipeline
       "date_index_name" : {
         "field" : "event.ingested",
         "index_name_prefix" : "corelight-zeek-audit_log-",
-        "date_formats": [ "yyyy-MM-dd'T'HH:mm:ss.SSSSSSXX", "yyyy-MM-dd'T'HH:mm:ss.SSSXX" ],
+        "date_formats": [ "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSXX", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSXX", "yyyy-MM-dd'T'HH:mm:ss.SSSXX" ],
         "date_rounding": "d",
         "ignore_failure": false,
         "index_name_format": "yyyy.MM.dd"

--- a/manual_install/corelight_metrics_general_pipeline
+++ b/manual_install/corelight_metrics_general_pipeline
@@ -14,7 +14,7 @@ PUT _ingest/pipeline/corelight_metrics_general_pipeline
       "date_index_name": {
         "field": "event.ingested",
         "index_name_prefix": "corelight-zeek-metrics-{{event.dataset}}-",
-        "date_formats": [ "yyyy-MM-dd'T'HH:mm:ss.SSSSSSXX", "yyyy-MM-dd'T'HH:mm:ss.SSSXX" ],
+        "date_formats": [ "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSXX", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSXX", "yyyy-MM-dd'T'HH:mm:ss.SSSXX" ],
         "date_rounding": "d",
         "ignore_failure": false,
         "index_name_format": "yyyy.MM.dd"

--- a/manual_install/corelight_stats_general_pipeline
+++ b/manual_install/corelight_stats_general_pipeline
@@ -14,7 +14,7 @@ PUT _ingest/pipeline/corelight_stats_general_pipeline
       "date_index_name" : {
         "field": "event.ingested",
         "index_name_prefix": "corelight-zeek-stats-{{event.dataset}}-",
-        "date_formats": [ "yyyy-MM-dd'T'HH:mm:ss.SSSSSSXX", "yyyy-MM-dd'T'HH:mm:ss.SSSXX" ],
+        "date_formats": [ "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSXX", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSXX", "yyyy-MM-dd'T'HH:mm:ss.SSSXX" ],
         "date_rounding": "d",
         "ignore_failure": false,
         "index_name_format": "yyyy.MM.dd"

--- a/manual_install/corelight_temporary_log_holdings_pipeline
+++ b/manual_install/corelight_temporary_log_holdings_pipeline
@@ -20,7 +20,7 @@ PUT _ingest/pipeline/corelight_temporary_log_holdings_pipeline
       "date_index_name" : {
         "field" : "event.ingested",
         "index_name_prefix" : "temp-corelight-{{event.dataset}}-",
-        "date_formats": [ "yyyy-MM-dd'T'HH:mm:ss.SSSSSSXX", "yyyy-MM-dd'T'HH:mm:ss.SSSXX" ],
+        "date_formats": [ "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSXX", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSXX", "yyyy-MM-dd'T'HH:mm:ss.SSSXX" ],
         "date_rounding": "d",
         "ignore_failure": false,
         "index_name_format": "yyyy.MM.dd"

--- a/manual_install/non-xpack-corelight_main_pipeline
+++ b/manual_install/non-xpack-corelight_main_pipeline
@@ -417,7 +417,7 @@ PUT _ingest/pipeline/corelight_main_pipeline
       "date_index_name" : {
         "field" : "event.ingested",
         "index_name_prefix" : "parse-failures-",
-        "date_formats": [ "yyyy-MM-dd'T'HH:mm:ss.SSSSSSXX", "yyyy-MM-dd'T'HH:mm:ss.SSSXX" ],
+        "date_formats": [ "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSXX", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSXX", "yyyy-MM-dd'T'HH:mm:ss.SSSXX" ],
         "date_rounding": "d",
         "ignore_failure": true,
         "index_name_format": "yyyy.MM.dd"

--- a/manual_install/template_corelight_metrics_and_stats
+++ b/manual_install/template_corelight_metrics_and_stats
@@ -50,86 +50,86 @@ PUT /_template/corelight_metrics_and_stats
           }
         }
       }
-    ]
-  },
-  "properties": {
-    "@timestamp": {
-      "type": "date"
-    },
-    "message": {
-      "norms": false,
-      "type": "text"
-    },
-    "labels": {
-      "type": "object"
-    },
-    "tags": {
-      "type": "keyword"
-    },
-    "event": {
-      "properties": {
-        "category": {
-          "ignore_above": 1024,
-          "type": "keyword"
-        },
-        "created": {
-          "type": "date"
-        },
-        "dataset": {
-          "ignore_above": 1024,
-          "type": "keyword"
-        },
-        "duration": {
-          "type": "long"
-        },
-        "end": {
-          "type": "date"
-        },
-        "facility": {
-          "type": "keyword"
-        },
-        "hash": {
-          "type": "keyword"
-        },
-        "id": {
-          "ignore_above": 1024,
-          "type": "keyword"
-        },
-        "kind": {
-          "ignore_above": 1024,
-          "type": "keyword"
-        },
-        "module": {
-          "ignore_above": 1024,
-          "type": "keyword"
-        },
-        "original": {
-          "doc_values": false,
-          "index": false,
-          "type": "keyword"
-        },
-        "outcome": {
-          "ignore_above": 1024,
-          "type": "keyword"
-        },
-        "priority": {
-          "type": "keyword"
-        },
-        "risk_score": {
-          "type": "float"
-        },
-        "risk_score_norm": {
-          "type": "float"
-        },
-        "severity": {
-          "type": "keyword"
-        },
-        "start": {
-          "type": "date"
-        },
-        "timezone": {
-          "ignore_above": 1024,
-          "type": "keyword"
+    ],
+    "properties": {
+      "@timestamp": {
+        "type": "date"
+      },
+      "message": {
+        "norms": false,
+        "type": "text"
+      },
+      "labels": {
+        "type": "object"
+      },
+      "tags": {
+        "type": "keyword"
+      },
+      "event": {
+        "properties": {
+          "category": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "created": {
+            "type": "date"
+          },
+          "dataset": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "duration": {
+            "type": "long"
+          },
+          "end": {
+            "type": "date"
+          },
+          "facility": {
+            "type": "keyword"
+          },
+          "hash": {
+            "type": "keyword"
+          },
+          "id": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "kind": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "module": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "original": {
+            "doc_values": false,
+            "index": false,
+            "type": "keyword"
+          },
+          "outcome": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "priority": {
+            "type": "keyword"
+          },
+          "risk_score": {
+            "type": "float"
+          },
+          "risk_score_norm": {
+            "type": "float"
+          },
+          "severity": {
+            "type": "keyword"
+          },
+          "start": {
+            "type": "date"
+          },
+          "timezone": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          }
         }
       }
     }

--- a/manual_install/xpack-corelight_main_pipeline
+++ b/manual_install/xpack-corelight_main_pipeline
@@ -417,7 +417,7 @@ PUT _ingest/pipeline/corelight_main_pipeline
       "date_index_name" : {
         "field" : "event.ingested",
         "index_name_prefix" : "parse-failures-",
-        "date_formats": [ "yyyy-MM-dd'T'HH:mm:ss.SSSSSSXX", "yyyy-MM-dd'T'HH:mm:ss.SSSXX" ],
+        "date_formats": [ "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSXX", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSXX", "yyyy-MM-dd'T'HH:mm:ss.SSSXX" ],
         "date_rounding": "d",
         "ignore_failure": true,
         "index_name_format": "yyyy.MM.dd"


### PR DESCRIPTION
Fixed several parse failure issues caused by no date/time format that matched event.ingested
Fixed template_corelight_metrics_and_stats formatting so that it no longer throws error when trying to import