### PR TITLE
v27 (#59)

### DIFF
--- a/automatic_install/corelight_dns_pipeline
+++ b/automatic_install/corelight_dns_pipeline
@@ -261,13 +261,6 @@
         "ignore_failure": true,
         "ignore_missing" : true
       }
-    },
-    {
-      "remove": {
-        "field": "id",
-        "ignore_failure": true,
-        "ignore_missing" : true
-      }
     }
   ]
 }

--- a/automatic_install/corelight_files_pipeline
+++ b/automatic_install/corelight_files_pipeline
@@ -41,7 +41,7 @@
     {
       "set": {
         "field": "destination.address",
-        "value": "{{files.rx_hosts}}",
+        "copy_from": "files.rx_hosts",
         "ignore_failure": true,
         "if": "ctx?.files?.rx_hosts != null"
       }
@@ -49,7 +49,7 @@
     {
       "set": {
         "field": "destination.ip",
-        "value": "{{files.rx_hosts}}",
+        "copy_from": "files.rx_hosts",
         "ignore_failure": true,
         "if": "ctx?.files?.rx_hosts != null"
       }
@@ -57,7 +57,7 @@
     {
       "set": {
         "field": "source.address",
-        "value": "{{files.tx_hosts}}",
+        "copy_from": "files.tx_hosts",
         "ignore_failure": true,
         "if": "ctx?.files?.tx_hosts != null"
       }
@@ -65,7 +65,7 @@
     {
       "set": {
         "field": "source.ip",
-        "value": "{{files.tx_hosts}}",
+        "copy_from": "files.tx_hosts",
         "ignore_failure": true,
         "if": "ctx?.files?.tx_hosts != null"
       }

--- a/automatic_install/corelight_general_pipeline
+++ b/automatic_install/corelight_general_pipeline
@@ -88,7 +88,8 @@
         "field": "id.orig_h",
         "target_field": "source.ip",
         "ignore_missing": true,
-        "if": "ctx?.id?.orig_h != null"
+        "if": "ctx?.id instanceof Map && ctx?.id?.orig_h != null",
+        "tag": "1"
       }
     },
     {
@@ -102,7 +103,7 @@
         "field": "id.orig_p",
         "target_field": "source.port",
         "ignore_missing": true,
-        "if": "ctx?.id?.orig_p != null"
+        "if": "ctx?.id instanceof Map && ctx?.id?.orig_p != null"
       }
     },
     {
@@ -116,7 +117,7 @@
         "field": "id.resp_h",
         "target_field": "destination.ip",
         "ignore_missing": true,
-        "if": "ctx?.id?.resp_h != null"
+        "if": "ctx?.id instanceof Map && ctx?.id?.resp_h != null"
       }
     },
     {
@@ -130,7 +131,7 @@
         "field": "id.resp_p",
         "target_field": "destination.port",
         "ignore_missing": true,
-        "if": "ctx?.id?.resp_p != null"
+        "if": "ctx?.id instanceof Map && ctx?.id?.resp_p != null"
       }
     },
     {

--- a/automatic_install/corelight_ipsec_pipeline
+++ b/automatic_install/corelight_ipsec_pipeline
@@ -1,0 +1,173 @@
+{
+    "description" : "Corelight IPSec pipeline. This pipeline is from the Github repository https://github.com/corelight/ecs-mapping. Please file all questions or issues with this configuration in the corresponding Github repository.",
+    "processors" : [
+      {
+        "set": {
+          "field": "temporary_metadata_index_name_suffix",
+          "value": "various",
+          "ignore_failure": false
+        }
+      },
+      {
+        "set": {
+          "field": "event.category",
+          "value": "network",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "certificates",
+          "target_field": "vpn.certificates",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "exchange_type",
+          "target_field": "vpn.exchange_type",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "flag_a",
+          "target_field": "vpn.flag_a",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "flag_c",
+          "target_field": "vpn.flag_c",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "flag_e",
+          "target_field": "vpn.flag_e",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "flag_i",
+          "target_field": "vpn.flag_i",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "flag_r",
+          "target_field": "vpn.flag_r",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "flag_v",
+          "target_field": "vpn.flag_v",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "hash",
+          "target_field": "vpn.hash",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "initiator_spi",
+          "target_field": "vpn.initiator_spi",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "is_orig",
+          "target_field": "vpn.is_originating",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "ke_dh_groups",
+          "target_field": "vpn.ke_dh_groups",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "length",
+          "target_field": "vpn.length",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "maj_ver",
+          "target_field": "vpn.maj_ver",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "message_id",
+          "target_field": "vpn.message_id",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "min_ver",
+          "target_field": "vpn.min_ver",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "notify_messages",
+          "target_field": "vpn.notify_messages",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "proposals",
+          "target_field": "vpn.proposals",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "responder_spi",
+          "target_field": "vpn.responder_spi",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "transform_attributes",
+          "target_field": "vpn.transform_attributes",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "transforms",
+          "target_field": "vpn.transforms",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "vendor_ids",
+          "target_field": "vpn.vendor_ids",
+          "ignore_failure": true
+        }
+      }
+    ]
+}

--- a/automatic_install/corelight_main_pipeline
+++ b/automatic_install/corelight_main_pipeline
@@ -135,6 +135,12 @@
     },
     {
       "pipeline": {
+        "if": "ctx.event.dataset == 'ipsec'",
+        "name": "corelight_ipsec_pipeline"
+      }
+    },
+    {
+      "pipeline": {
         "if": "ctx.event.dataset == 'irc'",
         "name": "corelight_irc_pipeline"
       }
@@ -395,6 +401,18 @@
       "pipeline": {
         "if": "ctx.event.dataset == 'software_red'",
         "name": "corelight_software_pipeline"
+      }
+    },
+    {
+      "pipeline": {
+        "if": "ctx.event.dataset == 'stun'",
+        "name": "corelight_stun_pipeline"
+      }
+    },
+    {
+      "pipeline": {
+        "if": "ctx.event.dataset == 'stun_nat'",
+        "name": "corelight_stun_nat_pipeline"
       }
     },
     {

--- a/automatic_install/corelight_pe_pipeline
+++ b/automatic_install/corelight_pe_pipeline
@@ -18,31 +18,25 @@
     {
       "rename": {
         "field": "id",
-        "target_field": "event.id",
-        "ignore_missing": true
+        "target_field": "log.id.id",
+        "ignore_missing": true,
+        "if": "ctx.id != null"
       }
     },
     {
       "set": {
         "field": "event.id",
-        "value": "{{fuid}}",
+        "value": "{{log.id.id}}",
         "ignore_failure": true,
-        "if": "ctx.fuid != null"
+        "if": "ctx.log?.id?.id != null"
       }
     },
     {
       "set": {
         "field": "log.id.fuid",
-        "value": "{{fuid}}",
+        "value": "{{log.id.id}}",
         "ignore_failure": true,
-        "if": "ctx.fuid != null"
-      }
-    },
-    {
-      "remove": {
-        "field": "fuid",
-        "ignore_failure": true,
-        "ignore_missing": true
+        "if": "ctx.log?.id?.id != null"
       }
     },
     {

--- a/automatic_install/corelight_postprocess_metadata_destination_domain_pipeline
+++ b/automatic_install/corelight_postprocess_metadata_destination_domain_pipeline
@@ -14,35 +14,40 @@
       "script" : {
         "lang" : "painless",
         "source": "ctx.destination.top_level_domain = ctx.destination.domain.substring(ctx.destination.domain.lastIndexOf('.')+1)",
-        "ignore_failure": true
+        "ignore_failure": true,
+        "if": "ctx.destination?.domain != null"
       }
     },
     {
       "script" : {
         "lang" : "painless",
         "source": "ctx.temp_without_top_level = ctx.destination.domain.substring(0,(ctx.destination.domain.lastIndexOf('.')))",
-        "ignore_failure": true
+        "ignore_failure": true,
+        "if": "ctx.destination?.domain != null"
       }
     },
     {
       "script" : {
         "lang" : "painless",
         "source": "ctx.destination.parent_domain = ctx.temp_without_top_level.substring(ctx.temp_without_top_level.lastIndexOf('.') + 1)",
-        "ignore_failure": true
+        "ignore_failure": true,
+        "if": "ctx.temp_without_top_level != null"
       }
     },
     {
       "script" : {
         "lang" : "painless",
         "source": "ctx.destination.subdomain = ctx.temp_without_top_level.substring(0,(ctx.temp_without_top_level.lastIndexOf('.')))",
-        "ignore_failure": true
+        "ignore_failure": true,
+        "if": "ctx.temp_without_top_level != null"
       }
     },
     {
       "script" : {
         "lang" : "painless",
         "source": "ctx.destination.registered_domain = ctx.destination.parent_domain + '.' + ctx.destination.top_level_domain",
-        "ignore_failure": true
+        "ignore_failure": true,
+        "if": "ctx.destination?.parent_domain != null"
       }
     },
     {

--- a/automatic_install/corelight_stun_nat_pipeline
+++ b/automatic_install/corelight_stun_nat_pipeline
@@ -1,0 +1,54 @@
+{
+    "description" : "Corelight Stun_NAT pipeline. This pipeline is from the Github repository https://github.com/corelight/ecs-mapping. Please file all questions or issues with this configuration in the corresponding Github repository.",
+    "processors" : [
+      {
+        "set": {
+          "field": "temporary_metadata_index_name_suffix",
+          "value": "various",
+          "ignore_failure": false
+        }
+      },
+      {
+        "set": {
+          "field": "event.category",
+          "value": "network",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "is_orig",
+          "target_field": "vpn.is_originating",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "lan_addrs",
+          "target_field": "vpn.lan_addrs",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "proto",
+          "target_field": "network.transport",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "wan_addrs",
+          "target_field": "vpn.wan_addrs",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "wan_ports",
+          "target_field": "vpn.wan_ports",
+          "ignore_failure": true
+        }
+      }
+    ]
+}

--- a/automatic_install/corelight_stun_pipeline
+++ b/automatic_install/corelight_stun_pipeline
@@ -1,0 +1,68 @@
+{
+    "description" : "Corelight Stun pipeline. This pipeline is from the Github repository https://github.com/corelight/ecs-mapping. Please file all questions or issues with this configuration in the corresponding Github repository.",
+    "processors" : [
+      {
+        "set": {
+          "field": "temporary_metadata_index_name_suffix",
+          "value": "various",
+          "ignore_failure": false
+        }
+      },
+      {
+        "set": {
+          "field": "event.category",
+          "value": "network",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "attr_types",
+          "target_field": "vpn.attr_types",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "attr_vals",
+          "target_field": "vpn.attr_vals",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "class",
+          "target_field": "vpn.class",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "is_orig",
+          "target_field": "vpn.is_originating",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "method",
+          "target_field": "vpn.method",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "proto",
+          "target_field": "network.transport",
+          "ignore_failure": true
+        }
+      },
+      {
+        "rename": {
+          "field": "trans_id",
+          "target_field": "vpn.trans_id",
+          "ignore_failure": true
+        }
+      }
+    ]
+}


### PR DESCRIPTION
* addition:
- merge all known_ into known- for upcoming change to those 5 corresponding logs



* change:
- event.duration multiply 1000000000 by NOT 1000000



* change:
- switch to ctx instead of containskey



* change:
- switch to ctx instead of containskey



* change:
- switch to ctx instead of containskey



* change:
- grab the first array value



* change:
- correct order of dot_expander



* change:
- index name should no longer prepend "ecs-" to match latest index templates



* addition:
- add more descriptive failure message



* change:
- switch to ctx checking of values instead of containskey



* addition:
- remove alert after no longer used



* change:
- switch to ctx checking of values instead of containskey



* change:
- collapse removes into one instead of 3 calls



* change:
- fix suricata.alert.metadata parsing. add checks.
- fix created_at and updated_at date conversion



* 26.3.1-(11/16/2022)
- Corelight 26.3 release, replaced dashes with underscores in Known-Entities package logs



* change:
- remove duplicate code block



* change:
- correct usage of id



* change:
- type checking of id field exists but id.orig/resp _h/_p do not



* addition:
- conditional checks for destination.domain enrichment



* change:
- use copy_from supported in => 7.11



* addition:
- v27 logs (ipsec, stun, stun_nat, wireguard)