### PR TITLE
Fixed typo in:  corelight-ecs-dns-pipeline

### DIFF
--- a/pipeline/log_specific/protocol_logs/corelight-ecs-dns-pipeline
+++ b/pipeline/log_specific/protocol_logs/corelight-ecs-dns-pipeline
@@ -186,7 +186,7 @@
     {
       "set": {
         "field": "destination.domain",
-        "value": "{{query}}}",
+        "value": "{{query}}",
         "ignore_failure": true,
         "if": "ctx.query != null"
       }


### PR DESCRIPTION
There was an extra '}' used when coping DNS domains resulting in an extra brace in the field value. 

Only appeared to be present when domains had multi-level subdomains.