### PR TITLE
Route ssh logs into their own dataset suffix

### DIFF
--- a/pipeline/log_specific/protocol_logs/corelight-ecs-ssh-pipeline
+++ b/pipeline/log_specific/protocol_logs/corelight-ecs-ssh-pipeline
@@ -44,7 +44,7 @@
     {
       "set": {
         "field": "temporary_metadata_index_name_dataset_suffix",
-        "value": "VAR_CL_DS_SUFFIX_PROTOCOL_LOG_VARIOUS",
+        "value": "VAR_CL_DS_SUFFIX_PROTOCOL_LOG_SSH",
         "ignore_failure": false
       }
     },


### PR DESCRIPTION
## Summary

The ssh ingest pipeline sets `temporary_metadata_index_name_dataset_suffix` to `VAR_CL_DS_SUFFIX_PROTOCOL_LOG_VARIOUS`, so ssh logs land in `logs-corelight.various-*` instead of a dedicated index. This changes it to `VAR_CL_DS_SUFFIX_PROTOCOL_LOG_SSH`.

## Why

Companion change to corelight/ecs-templates#47, which adds the SSH index template and the corresponding variable dict entries in `corelight_ecs.py`. That template needs this pipeline change to actually take effect. The two are meant to land together.